### PR TITLE
Added return value required by Symfony Console commands

### DIFF
--- a/src/Command/PlaygroundCommand.php
+++ b/src/Command/PlaygroundCommand.php
@@ -34,6 +34,6 @@ class PlaygroundCommand extends Command
         $params = array_map(function($param) {
             return $this->container->get($param->name);
         }, $rf->getParameters());
-        $playgroundFn(...$params);
+        return $playgroundFn(...$params) ?? 0;
     }
 }


### PR DESCRIPTION
- Every Symfony Console command needs to return a status code value, this change avoids Symfony Console component complain about it